### PR TITLE
Fixes

### DIFF
--- a/src/addon/configure/configure.tsx
+++ b/src/addon/configure/configure.tsx
@@ -68,7 +68,7 @@ configureRouter.post('/', async (c) => {
 					margin: '5px 0',
 				}}
 			>
-				{`https://${config().addon_url}/auth/${token}/manifest.json`}
+				{`${config().addon_url}/auth/${token}/manifest.json`}
 			</code>
 		</>,
 	);

--- a/src/common/constants/batches.ts
+++ b/src/common/constants/batches.ts
@@ -1,0 +1,2 @@
+export const BATCH_SIZE = 15;
+export const BATCH_DELAY = 200;

--- a/src/common/helpers/processInBatches.ts
+++ b/src/common/helpers/processInBatches.ts
@@ -1,0 +1,20 @@
+const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+export const processInBatches = async <T, R>(
+	items: T[],
+	batchSize: number,
+	delayMs: number,
+	fn: (item: T) => Promise<R>,
+): Promise<R[]> => {
+	const result: R[] = [];
+	for (let i = 0; i < items.length; i += batchSize) {
+		const batch = items.slice(i, i + batchSize);
+		const batchResults = await Promise.all(batch.map(fn));
+		result.push(...batchResults);
+
+		if (i + batchSize < items.length) {
+			await delay(delayMs);
+		}
+	}
+	return result;
+};

--- a/src/torrent/store/webtorrentStore.ts
+++ b/src/torrent/store/webtorrentStore.ts
@@ -25,7 +25,6 @@ export class TorrentStore {
 				{
 					path: config().download_dir,
 					deselect: true,
-					skipVerify: true,
 				},
 				(torrent) => {
 					console.log(

--- a/src/torrent/store/webtorrentStore.ts
+++ b/src/torrent/store/webtorrentStore.ts
@@ -25,6 +25,7 @@ export class TorrentStore {
 				{
 					path: config().download_dir,
 					deselect: true,
+					skipVerify: true,
 				},
 				(torrent) => {
 					console.log(


### PR DESCRIPTION
Made the following changes:

- Removed uncessecary `https` from code block, `config().addon_url` already contains it
- Implemented batch logic as nCore imposes limits after a lot of requests, I couldn't find out exact figures so I ballparked it. But it seems to work now. To reproduce the bug just request stream URLs for e.g. Game of Thrones.
- Replaced `restPagePromises.concat` with `restPagePromises.push` so it works now as intented

Everything else was made by Prettier.