### PR TITLE
Fix: Enable seeking in video playback

### DIFF
--- a/server/src/controllers/stream.controller.ts
+++ b/server/src/controllers/stream.controller.ts
@@ -115,6 +115,14 @@ export class StreamController {
     console.log(`Range: ${start}-${end}`);
 
     const stream = file.stream({ start, end });
-    return new Response(stream);
+    return new Response(stream, {
+      status: 206,
+      headers: {
+        'Content-Range': `bytes ${start}-${end}/${file.length}`,
+        'Content-Length': `${end - start + 1}`,
+        'Content-Type': fileType,
+        'Accept-Ranges': 'bytes',
+      },
+    });
   }
 }


### PR DESCRIPTION
This update resolves an issue where users were unable to seek through the video content during playback. With this fix, seeking functionality is now supported, allowing users to skip to different parts of the video seamlessly.