### PR TITLE
fix: selected file is sample file

### DIFF
--- a/server/src/services/torrent-source/types.ts
+++ b/server/src/services/torrent-source/types.ts
@@ -58,11 +58,16 @@ export abstract class TorrentDetails implements ParsedTorrentDetails {
       return biggestFileIndex;
     }
 
-    const parsedFileNames = this.files.map(
-      (file) => filenameParse(file.name, true) as ParsedShow,
-    );
-    const searchedEpisode = parsedFileNames.find((info) => {
-      return info.seasons?.includes(season) && info.episodeNumbers?.includes(episode);
+    const parsedFileNames = this.files.map((file) => ({
+      file,
+      parsed: filenameParse(file.name, true) as ParsedShow,
+    }));
+    const searchedEpisode = parsedFileNames.find(({ file, parsed }) => {
+      return (
+        !file.path.toLocaleLowerCase().includes('sample') &&
+        parsed.seasons?.includes(season) &&
+        parsed.episodeNumbers?.includes(episode)
+      );
     });
     return searchedEpisode ? parsedFileNames.indexOf(searchedEpisode) : -1;
   }


### PR DESCRIPTION
This PR aims to fix a bug, where sometimes the selected file for streaming is the sample file for a movie/show.