### PR TITLE
feat: visual update on stream description

### DIFF
--- a/server/src/controllers/stream.controller.ts
+++ b/server/src/controllers/stream.controller.ts
@@ -46,6 +46,8 @@ export class StreamController {
       user,
     });
 
+    const { preferredLanguage } = user;
+
     const streams = orderedTorrents.map((torrent, i) =>
       this.streamService.convertTorrentToStream({
         torrent,
@@ -53,6 +55,7 @@ export class StreamController {
         deviceToken,
         season,
         episode,
+        preferredLanguage,
       }),
     );
 

--- a/server/src/services/torrent-source/ncore/ncore-torrent-details.ts
+++ b/server/src/services/torrent-source/ncore/ncore-torrent-details.ts
@@ -25,6 +25,7 @@ export class NcoreTorrentDetails extends TorrentDetails {
 
   private category: TorrentCategory;
   private release_name: string;
+  private seeders: number;
 
   constructor(ncoreTorrent: NcoreTorrent, parsedDetails: ParsedTorrentDetails) {
     super();
@@ -39,6 +40,7 @@ export class NcoreTorrentDetails extends TorrentDetails {
       : Resolution.R720P;
     this.category = ncoreTorrent.category;
     this.release_name = ncoreTorrent.release_name;
+    this.seeders = ncoreTorrent.seeders;
   }
 
   public displayResolution(resolution: Resolution): string {
@@ -51,6 +53,10 @@ export class NcoreTorrentDetails extends TorrentDetails {
 
   public getLanguage(): Language {
     return HUNGARIAN_CATEGORIES.includes(this.category) ? Language.HU : Language.EN;
+  }
+
+  public getSeeders(): number {
+    return this.seeders;
   }
 
   private getNcoreResolutionByCategory = (category: TorrentCategory): NcoreResolution => {

--- a/server/src/services/torrent-source/ncore/types.ts
+++ b/server/src/services/torrent-source/ncore/types.ts
@@ -12,7 +12,7 @@ export type NcoreTorrent = {
   size: `${number}`;
   type: 'movie' | 'show';
   leechers: `${number}`;
-  seeders: `${number}`;
+  seeders: number;
 };
 
 export type NcorePageResponseJson = {

--- a/server/src/services/torrent-source/types.ts
+++ b/server/src/services/torrent-source/types.ts
@@ -41,6 +41,7 @@ export abstract class TorrentDetails implements ParsedTorrentDetails {
    */
   abstract displayResolution(resolution: Resolution): string;
   abstract getLanguage(): Language;
+  abstract getSeeders(): number;
   /**
    * Returns the name of the torrent. Usually the release name of the torrent.
    */


### PR DESCRIPTION
This PR enhances the stream description for series and movies by replacing torrent titles with file names for series, incorporates user-preferred language for text localization, and adds seeder count information.

![kép](https://github.com/user-attachments/assets/71dd6a0d-8685-4f01-8add-f5cb44dd08f9)
![kép](https://github.com/user-attachments/assets/92ab8930-a3a9-4301-89b4-918da5710625)


