### PR TITLE
fix: Swap ncore credentials in setup guide

### DIFF
--- a/docs/installation-guides/advanced/advanced.md
+++ b/docs/installation-guides/advanced/advanced.md
@@ -7,8 +7,8 @@ services:
   stremio-ncore-addon:
     image: detarkende/stremio-ncore-addon:0.6.0
     environment:
-      - NCORE_PASSWORD=
       - NCORE_USERNAME=
+      - NCORE_PASSWORD=
     ports:
       - target: 3000
         published: 3000

--- a/docs/installation-guides/beginners/local-only.md
+++ b/docs/installation-guides/beginners/local-only.md
@@ -77,8 +77,8 @@ name: stremio-ncore-addon
 services:
   stremio-ncore-addon:
     environment:
-      - NCORE_PASSWORD=
       - NCORE_USERNAME=
+      - NCORE_PASSWORD=
       - HTTPS_PORT=443
     image: detarkende/stremio-ncore-addon:0.6.0
     ports:

--- a/docs/installation-guides/beginners/remote-with-domain.md
+++ b/docs/installation-guides/beginners/remote-with-domain.md
@@ -113,8 +113,8 @@ name: stremio-ncore-addon
 services:
   stremio-ncore-addon:
     environment:
-      - NCORE_PASSWORD=
       - NCORE_USERNAME=
+      - NCORE_PASSWORD=
     image: detarkende/stremio-ncore-addon:0.6.0
     ports:
       - target: 3000


### PR DESCRIPTION
Hi,

In the documentation, the order of username and password is reversed, which can easily confuse users. If someone tries to set up the addon by following the documentation, they may enter their password as their username and vice versa, causing authentication to fail.

I have corrected the documentation to the correct oder.