### PR TITLE
Improve Torrent Handling in TorrentStoreService

### DIFF
--- a/server/src/controllers/stream.controller.ts
+++ b/server/src/controllers/stream.controller.ts
@@ -89,16 +89,11 @@ export class StreamController {
   public async play(c: Context<HonoEnv, string, { out: { param: PlaySchema } }>) {
     const { ncoreId, infoHash, filePath } = c.req.valid('param');
 
-    const torrentResult = await this.torrentStoreService.getTorrent(infoHash);
-    if (torrentResult.isErr()) {
-      // This is not a "not found" case, but rather a case where the torrent store threw an error
-      logger.error(
-        { error: torrentResult.error },
-        'Error while getting torrent from torrent server. Returning status 500',
-      );
-      throw new HTTPException(HttpStatusCode.INTERNAL_SERVER_ERROR);
-    }
-    let torrent = torrentResult.value;
+    const torrentResult = await this.torrentStoreService.getOrAddTorrent(
+      infoHash,
+      ncoreId,
+    );
+    let torrent = torrentResult;
 
     if (!torrent) {
       const torrentUrlResult = await this.ncoreService.getTorrentUrlByNcoreId(ncoreId);

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -75,7 +75,7 @@ const isAdmin = createAdminMiddleware(sessionService);
 const isAdminOrSelf = createAdminOrSelfMiddleware(sessionService);
 const isDeviceAuthenticated = createDeviceTokenMiddleware(userService);
 
-const torrentStoreService = new TorrentStoreService(ncoreService);
+const torrentStoreService = new TorrentStoreService(ncoreService, torrentService);
 
 await torrentStoreService.startServer();
 const streamService = new StreamService(configService, userService);


### PR DESCRIPTION
## Summary
This PR introduces a new helper method for automatic torrent management and improves the cleanup logic when deleting torrents.

### Changes
- **Added `getOrAddTorrent(infoHash, ncoreId)`**
  - If a torrent already exists or is being fetched, it returns it immediately.
  - If not found, it retrieves the torrent URL from nCore, downloads the `.torrent` file, and adds it to WebTorrent automatically.
  - Prevents multiple parallel downloads for the same torrent by caching ongoing requests.

- **Improved `deleteTorrent(infoHash)`**
  - Properly destroys the torrent and its data.
  - Deletes the corresponding `.torrent` file from disk.
  - Adds better error handling and detailed logging for cleanup operations.

These updates make torrent retrieval more reliable and ensure consistent resource cleanup across all operations.
